### PR TITLE
User cpu operators

### DIFF
--- a/java/tech/compute/cpu/BinaryOp.java
+++ b/java/tech/compute/cpu/BinaryOp.java
@@ -1,0 +1,7 @@
+package tech.compute.cpu;
+
+
+public interface BinaryOp
+{
+  double op(double lhs, double rhs);
+};

--- a/java/tech/compute/cpu/TernaryOp.java
+++ b/java/tech/compute/cpu/TernaryOp.java
@@ -1,6 +1,0 @@
-package tech.compute.cpu;
-
-public interface TernaryOp
-{
-  double op(double lhs, double mid, double rhs);
-}

--- a/java/tech/compute/cpu/TernaryOp.java
+++ b/java/tech/compute/cpu/TernaryOp.java
@@ -1,0 +1,6 @@
+package tech.compute.cpu;
+
+public interface TernaryOp
+{
+  double op(double lhs, double mid, double rhs);
+}

--- a/java/tech/compute/cpu/UnaryOp.java
+++ b/java/tech/compute/cpu/UnaryOp.java
@@ -1,0 +1,7 @@
+package tech.compute.cpu;
+
+
+public interface UnaryOp
+{
+  double op(double src);
+};

--- a/java/tech/compute/cpu/UnaryReduce.java
+++ b/java/tech/compute/cpu/UnaryReduce.java
@@ -1,0 +1,9 @@
+package tech.compute.cpu;
+
+
+public interface UnaryReduce
+{
+  double initialize(double first_value);
+  double update(double accum, double next_value);
+  double finalize(double accum, int num_elems);
+};

--- a/project.clj
+++ b/project.clj
@@ -6,4 +6,5 @@
   :plugins [[lein-tools-deps "0.4.1"]]
   :middleware [lein-tools-deps.plugin/resolve-dependencies-with-deps-edn]
   :lein-tools-deps/config {:config-files [:install :user :project]}
+  :java-source-paths ["java"]
   :profiles {:dev {:dependencies [[com.github.fommil.netlib/all "1.1.2" :extension "pom"]]}})

--- a/src/tech/compute/cpu/tensor_math.clj
+++ b/src/tech/compute/cpu/tensor_math.clj
@@ -90,7 +90,7 @@
   (when-not (instance? UnaryOp unary-op)
     (throw (ex-info "Operand is not a tech.compute.cpu.UnaryOp"
                     {:operand unary-op})))
-  (swap! custom-op-table assoc [keywd] {:type :unary
+  (swap! custom-op-table assoc keywd {:type :unary
                                         :operand unary-op})
   keywd)
 
@@ -100,7 +100,7 @@
   (when-not (instance? BinaryOp binary-op)
     (throw (ex-info "Operand is not a tech.compute.cpu.BinaryOp"
                     {:operand binary-op})))
-  (swap! custom-op-table assoc [keywd] {:type :binary
+  (swap! custom-op-table assoc keywd {:type :binary
                                         :operand binary-op})
   keywd)
 
@@ -110,7 +110,7 @@
   (when-not (instance? UnaryReduce unary-reduce-op)
     (throw (ex-info "Operand is not a tech.compute.cpu.BinaryOp"
                     {:operand unary-reduce-op})))
-  (swap! custom-op-table assoc [keywd] {:type :unary-reduce
+  (swap! custom-op-table assoc keywd {:type :unary-reduce
                                         :operand unary-reduce-op})
   keywd)
 
@@ -207,7 +207,8 @@
 
   (unary-accum! [stream dest alpha op]
     (cpu-driver/with-stream-dispatch stream
-      (if-let [built-in (get-in (unary-op-table) [[(dtype/get-datatype dest) op] :unary-accum!])]
+      (if-let [built-in (get-in (unary-op-table) [[(dtype/get-datatype dest) op]
+                                                  :unary-accum!])]
         (built-in
          (->buffer dest) (->dimensions dest) alpha (ct/ecount dest))
         (if-let [{:keys [type operand]} (get @custom-op-table op)]
@@ -215,14 +216,16 @@
             (when-not (= type :unary)
               (throw (ex-info "Custom operand is not a unary op"
                               {:op-type type})))
-            (let [built-in (get-in (unary-op-table) [[(dtype/get-datatype dest) :custom] :unary-accum!])]
+            (let [built-in (get-in (unary-op-table) [[(dtype/get-datatype dest) :custom]
+                                                     :unary-accum!])]
               (built-in
                (->buffer dest) (->dimensions dest) alpha (ct/ecount dest) operand)))
           (throw (ex-info "Failed to find operand" {:operand op}))))))
 
   (unary-op! [stream dest x alpha op]
     (cpu-driver/with-stream-dispatch stream
-      (if-let [built-in (get-in (unary-op-table) [[(dtype/get-datatype dest) op] :unary-op!])]
+      (if-let [built-in (get-in (unary-op-table) [[(dtype/get-datatype dest) op]
+                                                  :unary-op!])]
         (built-in
          (->buffer dest) (->dimensions dest) (->buffer x) (->dimensions x) alpha
          (max (ct/ecount dest) (ct/ecount x)))
@@ -231,9 +234,11 @@
             (when-not (= type :unary)
               (throw (ex-info "Custom operand is not a unary op"
                               {:op-type type})))
-            (let [built-in (get-in (unary-op-table) [[(dtype/get-datatype dest) :custom] :unary-op!])]
+            (let [built-in (get-in (unary-op-table) [[(dtype/get-datatype dest) :custom]
+                                                     :unary-op!])]
               (built-in
-               (->buffer dest) (->dimensions dest) alpha (ct/ecount dest) operand)))
+               (->buffer dest) (->dimensions dest) (->buffer x) (->dimensions x) alpha
+               (max (ct/ecount dest) (ct/ecount x)) operand)))
           (throw (ex-info "Failed to find operand" {:operand op}))))))
 
   (binary-accum-constant! [stream dest dest-alpha scalar operation reverse-operands?]

--- a/src/tech/compute/cpu/tensor_math/binary_accum.clj
+++ b/src/tech/compute/cpu/tensor_math/binary_accum.clj
@@ -51,8 +51,8 @@
   `(fn [dest# dest-dims# dest-alpha#
         scalar#
         n-elems#
-        reverse-operation?#
-        custom-op#]
+        custom-op#
+        reverse-operation?#]
      (let [n-elems# (long n-elems#)
            dest# (item->typed-nio-buffer ~datatype dest#)
            dest-idx->address# (get-elem-dims->address dest-dims#

--- a/src/tech/compute/cpu/tensor_math/binary_op.clj
+++ b/src/tech/compute/cpu/tensor_math/binary_op.clj
@@ -16,7 +16,8 @@
             [tech.datatype.java-unsigned :as unsigned]
             [tech.datatype.java-primitive :as primitive]
             [clojure.core.matrix.macros :refer [c-for]]
-            [tech.compute.tensor :as ct]))
+            [tech.compute.tensor :as ct])
+  (:import [tech.compute.cpu BinaryOp]))
 
 
 (set! *unchecked-math* :warn-on-boxed)
@@ -51,12 +52,59 @@
                                             scalar#))))))))
 
 
+(defmacro ^:private custom-binary-op-constant!-impl
+  [datatype]
+  `(fn [dest# dest-dims#
+        x# x-dims# x-alpha#
+        scalar#
+        n-elems#
+        custom-op#
+        reverse-operands?#]
+     (let [n-elems# (long n-elems#)
+           max-shape# (max-shape-from-dimensions dest-dims# x-dims#)
+           dest# (item->typed-nio-buffer ~datatype dest#)
+           dest-idx->address# (get-elem-dims->address dest-dims# max-shape#)
+           x# (item->typed-nio-buffer ~datatype x#)
+           x-idx->address# (get-elem-dims->address x-dims# max-shape#)
+           x-alpha# (datatype->cast-fn ~datatype x-alpha#)
+           scalar# (double (datatype->cast-fn ~datatype scalar#))
+           ^BinaryOp custom-op# custom-op#]
+       (if reverse-operands?#
+         (parallel/parallel-for
+          idx# (long n-elems#)
+          (let [dest-idx# (.idx_to_address dest-idx->address# idx#)
+                x-idx# (.idx_to_address x-idx->address# idx#)]
+            (b-put dest# dest-idx#
+                   (store-datatype-cast-fn
+                    ~datatype
+                    (.op custom-op#
+                         scalar#
+                         (* (read-datatype-cast-fn
+                             ~datatype
+                             (b-get x# x-idx#)) x-alpha#))))))
+         (parallel/parallel-for
+          idx# (long n-elems#)
+          (let [dest-idx# (.idx_to_address dest-idx->address# idx#)
+                x-idx# (.idx_to_address x-idx->address# idx#)]
+            (b-put dest# dest-idx#
+                   (store-datatype-cast-fn
+                    ~datatype
+                    (.op custom-op#
+                         (* (read-datatype-cast-fn
+                             ~datatype
+                             (b-get x# x-idx#)) x-alpha#)
+                         scalar#)))))))))
+
+
 (defmacro binary-op-constant-table
   []
-  (->> (for [dtype all-datatypes
-             op ct/binary-operations
-             rev-ops? [true false]]
-         [[dtype op rev-ops?] `(binary-op-constant!-impl ~dtype ~op ~rev-ops?)])
+  (->> (concat (for [dtype all-datatypes
+                     op ct/binary-operations
+                     rev-ops? [true false]]
+                 [[dtype op rev-ops?] `(binary-op-constant!-impl ~dtype ~op ~rev-ops?)])
+               (for [dtype all-datatypes]
+                 [[dtype :custom] `(custom-binary-op-constant!-impl ~dtype)]
+                 ))
        (into {})))
 
 
@@ -97,11 +145,49 @@
                                              (b-get y# y-idx#)) y-alpha#)))))))))
 
 
+(defmacro ^:private custom-binary-op!-impl
+  [datatype]
+  `(fn [dest# dest-dims#
+        x# x-dims# x-alpha#
+        y# y-dims# y-alpha#
+        n-elems#
+        custom-op#]
+     (let [n-elems# (long n-elems#)
+           max-shape# (max-shape-from-dimensions dest-dims# x-dims# y-dims#)
+           dest# (item->typed-nio-buffer ~datatype dest#)
+           dest-idx->address# (get-elem-dims->address dest-dims# max-shape#)
+           x# (item->typed-nio-buffer ~datatype x#)
+           x-idx->address# (get-elem-dims->address x-dims# max-shape#)
+           x-alpha# (datatype->cast-fn ~datatype x-alpha#)
+           y# (item->typed-nio-buffer ~datatype y#)
+           y-idx->address# (get-elem-dims->address y-dims# max-shape#)
+           y-alpha# (datatype->cast-fn ~datatype y-alpha#)
+           ^BinaryOp custom-op# custom-op#]
+       (parallel/parallel-for
+        idx# (long n-elems#)
+        (let [dest-idx# (.idx_to_address dest-idx->address# idx#)
+              x-idx# (.idx_to_address x-idx->address# idx#)
+              y-idx# (.idx_to_address y-idx->address# idx#)]
+          (b-put dest# dest-idx#
+                        (store-datatype-cast-fn
+                         ~datatype
+                         (.op custom-op#
+                              (* (read-datatype-cast-fn
+                                  ~datatype
+                                  (b-get x# x-idx#)) x-alpha#)
+                              (* (read-datatype-cast-fn
+                                  ~datatype
+                                  (b-get y# y-idx#)) y-alpha#)))))))))
+
+
 (defmacro binary-op-table-impl
   []
-  (->> (for [dtype all-datatypes
-             op ct/binary-operations]
-         [[dtype op] `(binary-op!-impl ~dtype ~op)])
+  (->> (concat (for [dtype all-datatypes
+                     op ct/binary-operations]
+                 [[dtype op] `(binary-op!-impl ~dtype ~op)])
+               (for [dtype all-datatypes]
+                 [[dtype :custom] `(custom-binary-op!-impl ~dtype)]
+                 ))
        (into {})))
 
 

--- a/src/tech/compute/cpu/tensor_math/unary_op.clj
+++ b/src/tech/compute/cpu/tensor_math/unary_op.clj
@@ -14,7 +14,8 @@
             [tech.datatype.java-unsigned :as unsigned]
             [tech.datatype.java-primitive :as primitive]
             [clojure.core.matrix.macros :refer [c-for]]
-            [tech.compute.tensor :as ct]))
+            [tech.compute.tensor :as ct])
+  (:import [tech.compute.cpu UnaryOp]))
 
 
 (set! *unchecked-math* :warn-on-boxed)
@@ -37,6 +38,29 @@
                         ~datatype
                         (unary-op-impl
                          ~operation
+                         (*
+                          (read-datatype-cast-fn
+                           ~datatype
+                           (b-get dest# dest-idx#))
+                          dest-alpha#)))))))))
+
+
+(defmacro ^:private custom-accum!-impl
+  [datatype]
+  `(fn [dest# dest-dims# dest-alpha#
+        n-elems# unary-op#]
+     (let [n-elems# (long n-elems#)
+           dest# (item->typed-nio-buffer ~datatype dest#)
+           dest-idx->address# (get-elem-dims->address dest-dims#
+                                                      (get dest-dims# :shape))
+           dest-alpha# (unsigned/datatype->cast-fn :ignored ~datatype dest-alpha#)
+           ^UnaryOp custom# unary-op#]
+       (c-for [idx# 0 (< idx# n-elems#) (inc idx#)]
+              (let [dest-idx# (.idx_to_address dest-idx->address# idx#)]
+                (b-put dest# dest-idx#
+                       (store-datatype-cast-fn
+                        ~datatype
+                        (.op custom#
                          (*
                           (read-datatype-cast-fn
                            ~datatype
@@ -70,12 +94,41 @@
                     x-alpha#))))))))
 
 
+(defmacro ^:private custom-unary-op!-impl
+  [datatype]
+  `(fn [dest# dest-dims#
+        x# x-dims# x-alpha#
+        n-elems# unary-op#]
+     (let [n-elems# (long n-elems#)
+           max-shape# (max-shape-from-dimensions dest-dims# x-dims#)
+           dest# (item->typed-nio-buffer ~datatype dest#)
+           dest-idx->address# (get-elem-dims->address dest-dims# max-shape#)
+           x# (item->typed-nio-buffer ~datatype x#)
+           x-idx->address# (get-elem-dims->address x-dims# max-shape#)
+           x-alpha# (unsigned/datatype->cast-fn :ignored ~datatype x-alpha#)
+           n-elems# (long n-elems#)
+           ^UnaryOp custom-op# unary-op#]
+       (parallel/parallel-for
+        idx# n-elems#
+        (b-put dest# (.idx_to_address dest-idx->address# idx#)
+               (store-datatype-cast-fn
+                ~datatype
+                (.op custom-op#
+                 (* (read-datatype-cast-fn
+                     ~datatype
+                     (b-get x# (.idx_to_address x-idx->address# idx#)))
+                    x-alpha#))))))))
+
+
 (defmacro unary-op-table-impl
   []
-  (->> (for [dtype all-datatypes
-             op ct/unary-operations]
-         [[dtype op] {:unary-accum! `(unary-accum!-impl ~dtype ~op)
-                      :unary-op! `(unary-op!-impl ~dtype ~op)}])
+  (->> (concat (for [dtype all-datatypes
+                     op ct/unary-operations]
+                 [[dtype op] {:unary-accum! `(unary-accum!-impl ~dtype ~op)
+                              :unary-op! `(unary-op!-impl ~dtype ~op)}])
+               (for [dtype all-datatypes]
+                 [[dtype :custom] {:unary-accum! `(custom-accum!-impl ~dtype)
+                                   :unary-op! `(custom-unary-op!-impl ~dtype)}]))
        (into {})))
 
 

--- a/src/tech/compute/cpu/tensor_math/unary_reduce.clj
+++ b/src/tech/compute/cpu/tensor_math/unary_reduce.clj
@@ -15,7 +15,8 @@
             [tech.datatype.java-unsigned :as unsigned]
             [tech.datatype.java-primitive :as primitive]
             [clojure.core.matrix.macros :refer [c-for]]
-            [tech.compute.tensor :as ct]))
+            [tech.compute.tensor :as ct])
+  (:import [tech.compute.cpu UnaryReduce]))
 
 
 (defmacro square-expr
@@ -41,7 +42,7 @@
 
 (defmacro perform-reduce
   [init-val update-val finalize-val
-  datatype op input addr in-alpha idx-start idx-stop]
+  datatype input addr in-alpha idx-start idx-stop]
   `(loop [sum-val# (~init-val (* ~in-alpha
                                  (read-datatype-cast-fn
                                   ~datatype
@@ -58,21 +59,37 @@
        (~finalize-val sum-val# (- ~idx-stop ~idx-start)))))
 
 
+(defmacro custom-init
+  [arg]
+  `(.initialize ~'custom (double ~arg)))
+
+
+(defmacro custom-update
+  [acc next]
+  `(.update ~'custom ~acc (double ~next)))
+
+
+(defmacro custom-finalize
+  [acc idx-range]
+  `(.finalize ~'custom (double ~acc) (int ~idx-range)))
+
+
 (defmacro do-unary-reduce-op
   [datatype op input addr in-alpha idx-start idx-stop]
   (condp = op
     :min `(perform-reduce identity-expr min identity-expr
-                          ~datatype ~op ~input ~addr ~in-alpha ~idx-start ~idx-stop)
+                          ~datatype ~input ~addr ~in-alpha ~idx-start ~idx-stop)
     :max `(perform-reduce identity-expr max identity-expr
-                          ~datatype ~op ~input ~addr ~in-alpha ~idx-start ~idx-stop)
+                          ~datatype ~input ~addr ~in-alpha ~idx-start ~idx-stop)
     :sum `(perform-reduce identity-expr + identity-expr
-                          ~datatype ~op ~input ~addr ~in-alpha ~idx-start ~idx-stop)
+                          ~datatype ~input ~addr ~in-alpha ~idx-start ~idx-stop)
     :mean `(perform-reduce identity-expr + /
-                           ~datatype ~op ~input ~addr ~in-alpha ~idx-start ~idx-stop)
+                           ~datatype ~input ~addr ~in-alpha ~idx-start ~idx-stop)
     :magnitude `(perform-reduce square-expr add-squared sqrt-expr
-                                ~datatype ~op ~input ~addr ~in-alpha ~idx-start ~idx-stop)
+                                ~datatype ~input ~addr ~in-alpha ~idx-start ~idx-stop)
     :magnitude-squared `(perform-reduce square-expr add-squared identity-expr
-                                        ~datatype ~op ~input ~addr ~in-alpha ~idx-start ~idx-stop)))
+                                        ~datatype ~input ~addr ~in-alpha ~idx-start ~idx-stop)))
+
 
 
 (defmacro unary-reduce-impl
@@ -98,11 +115,38 @@
                                                         iter-start# iter-stop#))))))))
 
 
+(defmacro custom-unary-reduce-impl
+  [datatype]
+  `(fn [output# output-dims# input-alpha# input# input-dims# unary-op#]
+     (let [input-shape# (ct-dims/shape input-dims#)
+           output-addr# (get-elem-dims->address output-dims#
+                                                (ct-dims/shape output-dims#))
+           input-addr# (get-elem-dims->address input-dims# (ct-dims/shape input-dims#))
+           input# (item->typed-nio-buffer ~datatype input#)
+           output# (item->typed-nio-buffer ~datatype output#)
+           input-alpha# (datatype->cast-fn ~datatype input-alpha#)
+           parallelism# (ct-dims/ecount output-dims#)
+           iter-amount# (quot (ct-dims/ecount input-dims#)
+                              parallelism#)
+           ^UnaryReduce ~'custom unary-op#]
+       (parallel/parallel-for
+        par-idx# parallelism#
+        (let [iter-start# (* par-idx# iter-amount#)
+              iter-stop# (+ iter-start# iter-amount#)]
+         (b-put output# (.idx_to_address output-addr# par-idx#)
+                (store-datatype-cast-fn
+                 ~datatype
+                 (perform-reduce custom-init custom-update custom-finalize
+                                 ~datatype input# input-addr# input-alpha# iter-start# iter-stop#))))))))
+
+
 (defmacro unary-reduce-iter
   []
-  (->> (for [dtype all-datatypes
-             reduce-op ct/unary-reduction-operations]
-         [[dtype reduce-op] {:unary-reduce! `(unary-reduce-impl ~dtype ~reduce-op)}])
+  (->> (concat (for [dtype all-datatypes
+                     reduce-op ct/unary-reduction-operations]
+                 [[dtype reduce-op] {:unary-reduce! `(unary-reduce-impl ~dtype ~reduce-op)}])
+               (for [dtype all-datatypes]
+                 [[dtype :custom] {:unary-reduce! `(custom-unary-reduce-impl ~dtype)}]))
        (into {})))
 
 

--- a/test/tech/compute/cpu/tensor_test.clj
+++ b/test/tech/compute/cpu/tensor_test.clj
@@ -17,7 +17,7 @@
             [tech.datatype :as dtype]
             [tech.datatype.jna :as dtype-jna]
             [clojure.core.matrix :as m])
-  (:import [tech.compute.cpu UnaryOp BinaryOp]))
+  (:import [tech.compute.cpu UnaryOp BinaryOp UnaryReduce]))
 
 
 (use-fixtures :each test-wrapper)
@@ -175,7 +175,7 @@
   (ct-defaults/tensor-driver-context
    (driver) *datatype*
    (cpu-tm/add-unary-op! :test-unary (reify UnaryOp
-                                       (^double op [this ^double val]
+                                       (op [this val]
                                          (double (* 10.0 val)))))
    (let [test-tens (ct/->tensor (range 10))
          copy-result (ct/unary-op! (ct/from-prototype test-tens)
@@ -193,8 +193,8 @@
   (ct-defaults/tensor-driver-context
    (driver) *datatype*
    (cpu-tm/add-binary-op! :test-binary (reify BinaryOp
-                                         (^double op [this ^double lhs ^double rhs]
-                                          (double (- lhs (* 2 rhs))))))
+                                         (op [this lhs rhs]
+                                           (double (- lhs (* 2 rhs))))))
    (let [test-tens (ct/->tensor (range 5 15))
 
          const-result (ct/binary-op! (ct/from-prototype test-tens)
@@ -219,3 +219,21 @@
             (mapv double (dtype/->vector accum-result))))
      (is (= [-8.0 -10.0 -12.0 -14.0 -16.0 -18.0 -20.0 -22.0 -24.0 -26.0]
             (mapv double (dtype/->vector const-accum-reverse)))))))
+
+
+(def-all-dtype-test custom-unary-reduce
+  (cpu-tm/add-unary-reduce!
+   :custom-reduce (reify UnaryReduce
+                    (^double initialize [this ^double first-val]
+                     first-val)
+                    (^double update [this ^double accum ^double next_value]
+                     (+ accum next_value))
+                    (finalize [this accum num-elems]
+                      (/ accum (double num-elems)))))
+  (let [src-matrix (ct/->tensor [[1 2 3]
+                                 [4 5 6]
+                                 [7 8 9]])
+        dst-val (ct/unary-reduce! (ct/new-tensor [3 1])
+                                  1.0 src-matrix :custom-reduce)]
+    (is (= [2.0 5.0 8.0]
+           (mapv double (dtype/->vector dst-val))))))


### PR DESCRIPTION
Users can now define their own unary, binary, and unary-reduce operators without needing to change the backend.